### PR TITLE
Adding step and annotation registry provider (Fixes #57)

### DIFF
--- a/berrycrush/api/src/main/kotlin/org/berrycrush/assertion/Assertion.kt
+++ b/berrycrush/api/src/main/kotlin/org/berrycrush/assertion/Assertion.kt
@@ -52,6 +52,7 @@ package org.berrycrush.assertion
 @MustBeDocumented
 @Repeatable
 annotation class Assertion(
-    val pattern: String,
+    val value: String = "",
+    val pattern: String = "",
     val description: String = "",
 )

--- a/berrycrush/api/src/main/kotlin/org/berrycrush/step/Step.kt
+++ b/berrycrush/api/src/main/kotlin/org/berrycrush/step/Step.kt
@@ -39,6 +39,7 @@ package org.berrycrush.step
 @MustBeDocumented
 @Repeatable
 annotation class Step(
-    val pattern: String,
+    val value: String = "",
+    val pattern: String = "",
     val description: String = "",
 )

--- a/berrycrush/core/src/main/kotlin/org/berrycrush/assertion/AnnotationAssertionScanner.kt
+++ b/berrycrush/core/src/main/kotlin/org/berrycrush/assertion/AnnotationAssertionScanner.kt
@@ -26,7 +26,7 @@ class AnnotationAssertionScanner : AnnotationScanner<AssertionDefinition> {
 
         return clazz.scanMethodAnnotations(Assertion::class) { method, annotation ->
             AssertionDefinition(
-                pattern = annotation.pattern,
+                pattern = annotation.pattern.ifEmpty { annotation.value },
                 method = method,
                 instance = if (Modifier.isStatic(method.modifiers)) null else actualInstance,
                 description = annotation.description,

--- a/berrycrush/core/src/main/kotlin/org/berrycrush/step/AnnotationStepScanner.kt
+++ b/berrycrush/core/src/main/kotlin/org/berrycrush/step/AnnotationStepScanner.kt
@@ -2,15 +2,9 @@ package org.berrycrush.step
 
 import org.berrycrush.scanner.AnnotationScanner
 import org.berrycrush.scanner.createInstance
-import org.berrycrush.scanner.forAllAnnotation
 import org.berrycrush.scanner.scanMethodAnnotations
 import org.berrycrush.util.StepDefinition
 import java.lang.reflect.Modifier
-import kotlin.reflect.KVisibility
-import kotlin.reflect.full.memberFunctions
-import kotlin.reflect.full.memberProperties
-import kotlin.reflect.jvm.isAccessible
-import kotlin.reflect.jvm.javaMethod
 
 /**
  * Scans classes for methods annotated with [@Step].
@@ -34,7 +28,7 @@ class AnnotationStepScanner : AnnotationScanner<StepDefinition> {
         return clazz.scanMethodAnnotations(Step::class) { method, annotation ->
             val isStatic = Modifier.isStatic(method.modifiers)
             StepDefinition(
-                pattern = annotation.pattern,
+                pattern = annotation.pattern.ifEmpty { annotation.value },
                 method = method,
                 instance = if (isStatic) null else actualInstance,
                 description = annotation.description,

--- a/berrycrush/junit/src/main/kotlin/org/berrycrush/junit/engine/BerryCrushTestEngine.kt
+++ b/berrycrush/junit/src/main/kotlin/org/berrycrush/junit/engine/BerryCrushTestEngine.kt
@@ -5,6 +5,7 @@ import org.berrycrush.junit.BerryCrushSpec
 import org.berrycrush.junit.BerryCrushSpecs
 import org.berrycrush.junit.ScenarioTest
 import org.berrycrush.junit.spi.BindingsProvider
+import org.berrycrush.junit.spi.RegistryProvider
 import org.junit.platform.engine.EngineDiscoveryRequest
 import org.junit.platform.engine.EngineExecutionListener
 import org.junit.platform.engine.ExecutionRequest
@@ -49,8 +50,15 @@ class BerryCrushTestEngine : TestEngine {
             .sortedByDescending { it.priority() }
     }
 
+    private val registryProviders: List<RegistryProvider> by lazy {
+        ServiceLoader
+            .load(RegistryProvider::class.java)
+            .toList()
+            .sortedByDescending { it.priority() }
+    }
+
     private val executor: ScenarioTestExecutor by lazy {
-        ScenarioTestExecutor(bindingsProviders)
+        ScenarioTestExecutor(bindingsProviders, registryProviders)
     }
 
     /**

--- a/berrycrush/junit/src/main/kotlin/org/berrycrush/junit/engine/ScenarioTestExecutor.kt
+++ b/berrycrush/junit/src/main/kotlin/org/berrycrush/junit/engine/ScenarioTestExecutor.kt
@@ -12,6 +12,8 @@ import org.berrycrush.junit.binding.OpenApiSpecValue
 import org.berrycrush.junit.discovery.FragmentDiscovery
 import org.berrycrush.junit.engine.context.TestExecutionContext
 import org.berrycrush.junit.spi.BindingsProvider
+import org.berrycrush.junit.spi.Provider
+import org.berrycrush.junit.spi.RegistryProvider
 import org.berrycrush.model.FragmentRegistry
 import org.berrycrush.plugin.PluginRegistry
 import org.berrycrush.runner.ScenarioRunner
@@ -42,6 +44,7 @@ import kotlin.reflect.full.findAnnotation
  */
 class ScenarioTestExecutor(
     private val bindingsProviders: List<BindingsProvider>,
+    private val registryProviders: List<RegistryProvider>,
 ) {
     /**
      * Execute all tests for a class descriptor.
@@ -60,26 +63,27 @@ class ScenarioTestExecutor(
         listener: EngineExecutionListener,
         filters: ScenarioFilters = ScenarioFilters.EMPTY,
     ) {
-        val provider = findBindingsProvider(classDescriptor.testClass)
-
+        val provider = bindingsProviders.findProvider(classDescriptor.testClass)
+        val registryProvider = registryProviders.findProvider(classDescriptor.testClass)
         try {
             provider?.initialize(classDescriptor.testClass.java)
-            executeWithContext(classDescriptor, listener, provider)
+            registryProvider?.initialize(classDescriptor.testClass.java)
+            executeWithContext(classDescriptor, listener, provider, registryProvider)
         } finally {
             runCatching { provider?.cleanup(classDescriptor.testClass.java) }
                 .onFailure { logger.log(Level.WARNING, it) { "BindingsProvider cleanup failed: ${it.message}" } }
         }
     }
 
-    private fun findBindingsProvider(testClass: KClass<*>): BindingsProvider? =
-        bindingsProviders.firstOrNull { it.supports(testClass.java) }
+    private fun <T : Provider> List<T>.findProvider(testClass: KClass<*>): T? = this.firstOrNull { it.supports(testClass.java) }
 
     private fun executeWithContext(
         classDescriptor: ClassTestDescriptor,
         listener: EngineExecutionListener,
         provider: BindingsProvider?,
+        registryProvider: RegistryProvider?,
     ) {
-        val context = buildExecutionContext(classDescriptor, provider)
+        val context = buildExecutionContext(classDescriptor, provider, registryProvider)
 
         context.beginExecution()
         try {
@@ -95,6 +99,7 @@ class ScenarioTestExecutor(
     private fun buildExecutionContext(
         classDescriptor: ClassTestDescriptor,
         provider: BindingsProvider?,
+        registryProvider: RegistryProvider?,
     ): TestExecutionContext {
         val suite = BerryCrushSuite.create()
         val bindings = createBindings(classDescriptor, provider)
@@ -103,8 +108,8 @@ class ScenarioTestExecutor(
 
         val pluginRegistry = createPluginRegistry(classDescriptor)
         val fragmentRegistry = loadFragments(classDescriptor)
-        val stepRegistry = createStepRegistry(classDescriptor)
-        val assertionRegistry = createAssertionRegistry(classDescriptor)
+        val stepRegistry = createStepRegistry(classDescriptor, registryProvider)
+        val assertionRegistry = createAssertionRegistry(classDescriptor, registryProvider)
         val configuration = BerryCrushConfigurationProvider.from(suite.configuration)
         val runner =
             ScenarioRunner(
@@ -307,15 +312,23 @@ class ScenarioTestExecutor(
      * Creates a StepRegistry with step definitions from @BerryCrushConfiguration.stepClasses.
      * Returns null if no step classes are configured.
      */
-    private fun createStepRegistry(classDescriptor: ClassTestDescriptor): StepRegistry? =
-        RegistryFactory.createStepRegistry(classDescriptor.testClass.java)
+    private fun createStepRegistry(
+        classDescriptor: ClassTestDescriptor,
+        registryProvider: RegistryProvider?,
+    ): StepRegistry? =
+        registryProvider?.createStepRegistry(classDescriptor.testClass.java)
+            ?: RegistryFactory.createStepRegistry(classDescriptor.testClass.java)
 
     /**
      * Creates an AssertionRegistry with assertion definitions from @BerryCrushConfiguration.assertionClasses.
      * Returns null if no assertion classes are configured.
      */
-    private fun createAssertionRegistry(classDescriptor: ClassTestDescriptor): AssertionRegistry? =
-        RegistryFactory.createAssertionRegistry(classDescriptor.testClass.java)
+    private fun createAssertionRegistry(
+        classDescriptor: ClassTestDescriptor,
+        registryProvider: RegistryProvider?,
+    ): AssertionRegistry? =
+        registryProvider?.createAssertionRegistry(classDescriptor.testClass.java)
+            ?: RegistryFactory.createAssertionRegistry(classDescriptor.testClass.java)
 
     companion object {
         private const val CLASSPATH_PREFIX = "classpath:"

--- a/berrycrush/junit/src/main/kotlin/org/berrycrush/junit/spi/BindingsProvider.kt
+++ b/berrycrush/junit/src/main/kotlin/org/berrycrush/junit/spi/BindingsProvider.kt
@@ -28,34 +28,7 @@ import org.berrycrush.junit.BerryCrushBindings
  * }
  * ```
  */
-interface BindingsProvider {
-    /**
-     * Determines if this provider supports the given test class.
-     *
-     * @param testClass The test class being executed
-     * @return true if this provider can handle bindings for this test class
-     */
-    fun supports(testClass: Class<*>): Boolean
-
-    /**
-     * Priority of this provider. Higher values indicate higher priority.
-     * When multiple providers support a test class, the one with highest
-     * priority is used.
-     *
-     * @return Priority value (default implementations should return 0)
-     */
-    fun priority(): Int = 0
-
-    /**
-     * Initializes the provider for the given test class.
-     * Called once before any scenarios are executed.
-     *
-     * For Spring integration, this starts the ApplicationContext.
-     *
-     * @param testClass The test class being executed
-     */
-    fun initialize(testClass: Class<*>)
-
+interface BindingsProvider : Provider {
     /**
      * Creates a BerryCrushBindings instance for the given test class.
      *
@@ -84,14 +57,4 @@ interface BindingsProvider {
      * @return A test instance with dependencies injected, or null to use default instantiation
      */
     fun createTestInstance(testClass: Class<*>): Any? = null
-
-    /**
-     * Cleans up resources after test execution completes.
-     * Called once after all scenarios have executed.
-     *
-     * For Spring integration, this releases the ApplicationContext.
-     *
-     * @param testClass The test class that was executed
-     */
-    fun cleanup(testClass: Class<*>)
 }

--- a/berrycrush/junit/src/main/kotlin/org/berrycrush/junit/spi/Provider.kt
+++ b/berrycrush/junit/src/main/kotlin/org/berrycrush/junit/spi/Provider.kt
@@ -1,0 +1,40 @@
+package org.berrycrush.junit.spi
+
+interface Provider {
+    /**
+     * Determines if this provider supports the given test class.
+     *
+     * @param testClass The test class being executed
+     * @return true if this provider can handle bindings for this test class
+     */
+    fun supports(testClass: Class<*>): Boolean
+
+    /**
+     * Priority of this provider. Higher values indicate higher priority.
+     * When multiple providers support a test class, the one with highest
+     * priority is used.
+     *
+     * @return Priority value (default implementations should return 0)
+     */
+    fun priority(): Int = 0
+
+    /**
+     * Initializes the provider for the given test class.
+     * Called once before any scenarios are executed.
+     *
+     * For Spring integration, this starts the ApplicationContext.
+     *
+     * @param testClass The test class being executed
+     */
+    fun initialize(testClass: Class<*>)
+
+    /**
+     * Cleans up resources after test execution completes.
+     * Called once after all scenarios have executed.
+     *
+     * For Spring integration, this releases the ApplicationContext.
+     *
+     * @param testClass The test class that was executed
+     */
+    fun cleanup(testClass: Class<*>)
+}

--- a/berrycrush/junit/src/main/kotlin/org/berrycrush/junit/spi/RegistryProvider.kt
+++ b/berrycrush/junit/src/main/kotlin/org/berrycrush/junit/spi/RegistryProvider.kt
@@ -1,0 +1,19 @@
+package org.berrycrush.junit.spi
+
+import org.berrycrush.assertion.AssertionRegistry
+import org.berrycrush.util.StepRegistry
+
+/**
+ * Custom step registry provider
+ */
+interface RegistryProvider : Provider {
+    /**
+     * Creates a StepRegistry instance for the given test class.
+     */
+    fun createStepRegistry(testClass: Class<*>): StepRegistry?
+
+    /**
+     * Creates an AssertionRegistry instance for the given test class.
+     */
+    fun createAssertionRegistry(testClass: Class<*>): AssertionRegistry?
+}

--- a/berrycrush/spring/src/main/kotlin/org/berrycrush/spring/SpringBindingsProvider.kt
+++ b/berrycrush/spring/src/main/kotlin/org/berrycrush/spring/SpringBindingsProvider.kt
@@ -1,8 +1,11 @@
 package org.berrycrush.spring
 
+import org.berrycrush.assertion.AssertionRegistry
 import org.berrycrush.exception.ConfigurationException
 import org.berrycrush.junit.BerryCrushBindings
 import org.berrycrush.junit.spi.BindingsProvider
+import org.berrycrush.junit.spi.RegistryProvider
+import org.berrycrush.util.StepRegistry
 import org.springframework.boot.test.context.SpringBootTest
 import java.util.concurrent.ConcurrentHashMap
 
@@ -21,7 +24,9 @@ import java.util.concurrent.ConcurrentHashMap
  * The provider is automatically discovered via ServiceLoader when the
  * berrycrush-spring module is on the classpath.
  */
-class SpringBindingsProvider : BindingsProvider {
+class SpringBindingsProvider :
+    BindingsProvider,
+    RegistryProvider {
     /**
      * Cache of SpringContextAdapter instances per test class.
      * This enables context reuse within a single test class execution.
@@ -79,12 +84,7 @@ class SpringBindingsProvider : BindingsProvider {
         testClass: Class<*>,
         bindingsClass: Class<out BerryCrushBindings>,
     ): BerryCrushBindings {
-        val adapter =
-            contextAdapters[testClass]
-                ?: throw ConfigurationException(
-                    "Spring context not initialized for test class: ${testClass.name}. " +
-                        "Ensure initialize() was called before createBindings().",
-                )
+        val adapter = getAdapter(testClass, "createBindings")
 
         // Try to get from Spring context first, fall back to direct instantiation
         return adapter.getBeanOrNull(bindingsClass)
@@ -103,14 +103,18 @@ class SpringBindingsProvider : BindingsProvider {
      * @throws ConfigurationException if context not initialized
      */
     override fun createTestInstance(testClass: Class<*>): Any {
-        val adapter =
-            contextAdapters[testClass]
-                ?: throw ConfigurationException(
-                    "Spring context not initialized for test class: ${testClass.name}. " +
-                        "Ensure initialize() was called before createTestInstance().",
-                )
-
+        val adapter = getAdapter(testClass, "createTestInstance")
         return adapter.getTestInstance()
+    }
+
+    override fun createAssertionRegistry(testClass: Class<*>): AssertionRegistry? {
+        val adapter = getAdapter(testClass, "createAssertionRegistry")
+        return adapter.getBeanOrNull(AssertionRegistry::class.java)
+    }
+
+    override fun createStepRegistry(testClass: Class<*>): StepRegistry? {
+        val adapter = getAdapter(testClass, "createStepRegistry")
+        return adapter.getBeanOrNull(StepRegistry::class.java)
     }
 
     /**
@@ -123,4 +127,14 @@ class SpringBindingsProvider : BindingsProvider {
     override fun cleanup(testClass: Class<*>) {
         contextAdapters.remove(testClass)?.cleanup()
     }
+
+    private fun getAdapter(
+        testClass: Class<*>,
+        methodName: String,
+    ): SpringContextAdapter =
+        contextAdapters[testClass]
+            ?: throw ConfigurationException(
+                "Spring context not initialized for test class: ${testClass.name}. " +
+                    "Ensure initialize() was called before $methodName().",
+            )
 }

--- a/berrycrush/spring/src/main/kotlin/org/berrycrush/spring/SpringStepDiscovery.kt
+++ b/berrycrush/spring/src/main/kotlin/org/berrycrush/spring/SpringStepDiscovery.kt
@@ -1,5 +1,11 @@
 package org.berrycrush.spring
 
+import org.berrycrush.assertion.AnnotationAssertionScanner
+import org.berrycrush.assertion.Assertion
+import org.berrycrush.assertion.AssertionDefinition
+import org.berrycrush.assertion.AssertionRegistry
+import org.berrycrush.assertion.DefaultAssertionRegistry
+import org.berrycrush.scanner.AnnotationScanner
 import org.berrycrush.step.AnnotationStepScanner
 import org.berrycrush.step.DefaultStepRegistry
 import org.berrycrush.step.Step
@@ -40,7 +46,8 @@ import org.springframework.context.annotation.Configuration
  */
 @Configuration
 class SpringStepDiscovery {
-    private val annotationScanner = AnnotationStepScanner()
+    private val annotationStepScanner = AnnotationStepScanner()
+    private val annotationAssertionScanner = AnnotationAssertionScanner()
 
     /**
      * Creates a StepRegistry bean populated with all step definitions
@@ -57,6 +64,14 @@ class SpringStepDiscovery {
         return registry
     }
 
+    @Bean
+    fun assertionRegistry(context: ApplicationContext): AssertionRegistry {
+        val registry = DefaultAssertionRegistry()
+        val definitions = discoverAssertions(context)
+        registry.registerAll(definitions)
+        return registry
+    }
+
     /**
      * Discovers all step definitions from Spring-managed beans.
      *
@@ -66,14 +81,24 @@ class SpringStepDiscovery {
      * @param context The Spring ApplicationContext
      * @return List of discovered StepDefinitions
      */
-    fun discoverSteps(context: ApplicationContext): List<StepDefinition> =
+    private fun discoverSteps(context: ApplicationContext): List<StepDefinition> =
+        discover(context, Step::class.java, annotationStepScanner)
+
+    private fun discoverAssertions(context: ApplicationContext): List<AssertionDefinition> =
+        discover(context, Assertion::class.java, annotationAssertionScanner)
+
+    private inline fun <reified T, A : Annotation> discover(
+        context: ApplicationContext,
+        annotationClass: Class<A>,
+        scanner: AnnotationScanner<T>,
+    ): List<T> =
         context.beanDefinitionNames
             .mapNotNull { beanName ->
                 runCatching {
                     val bean = context.getBean(beanName)
                     val beanClass = bean.javaClass
-                    val hasStepMethods = beanClass.declaredMethods.any { it.isAnnotationPresent(Step::class.java) }
-                    if (hasStepMethods) annotationScanner.scan(beanClass, bean) else null
+                    val hasAnnotatedMethods = beanClass.declaredMethods.any { it.isAnnotationPresent(annotationClass) }
+                    if (hasAnnotatedMethods) scanner.scan(beanClass, bean) else null
                 }.getOrNull()
             }.flatten()
 }

--- a/berrycrush/spring/src/main/resources/META-INF/services/org.berrycrush.junit.spi.RegistryProvider
+++ b/berrycrush/spring/src/main/resources/META-INF/services/org.berrycrush.junit.spi.RegistryProvider
@@ -1,0 +1,1 @@
+org.berrycrush.spring.SpringBindingsProvider

--- a/berrycrush/spring/src/test/kotlin/org/berrycrush/spring/SpringBindingsProviderErrorTest.kt
+++ b/berrycrush/spring/src/test/kotlin/org/berrycrush/spring/SpringBindingsProviderErrorTest.kt
@@ -77,6 +77,34 @@ class SpringBindingsProviderErrorTest {
         )
     }
 
+    @Test
+    fun `createAssertionRegistry throws error when context not initialized`() {
+        // Try to create bindings without initializing first
+        val exception =
+            assertThrows<ConfigurationException> {
+                provider.createAssertionRegistry(MissingSpringBootTestClass::class.java)
+            }
+
+        assertTrue(
+            exception.message!!.contains("not initialized"),
+            "Error should indicate context is not initialized",
+        )
+    }
+
+    @Test
+    fun `createStepRegistry throws error when context not initialized`() {
+        // Try to create bindings without initializing first
+        val exception =
+            assertThrows<ConfigurationException> {
+                provider.createStepRegistry(MissingSpringBootTestClass::class.java)
+            }
+
+        assertTrue(
+            exception.message!!.contains("not initialized"),
+            "Error should indicate context is not initialized",
+        )
+    }
+
     // Test fixtures
 
     @SpringBootApplication(exclude = [DataSourceAutoConfiguration::class])

--- a/berrycrush/spring/src/test/kotlin/org/berrycrush/spring/SpringBindingsProviderTest.kt
+++ b/berrycrush/spring/src/test/kotlin/org/berrycrush/spring/SpringBindingsProviderTest.kt
@@ -64,6 +64,11 @@ class SpringBindingsProviderTest {
         assertNotNull(bindingsMap["baseUrl"])
         assertTrue((bindingsMap["baseUrl"] as String).startsWith("http://localhost:"))
 
+        val stepRegistry = provider.createStepRegistry(ValidTestClass::class.java)
+        assertNotNull(stepRegistry)
+        val assertionRegistry = provider.createAssertionRegistry(ValidTestClass::class.java)
+        assertNotNull(assertionRegistry)
+
         // Cleanup
         provider.cleanup(ValidTestClass::class.java)
     }

--- a/samples/webflux/scenario/src/test/java/org/berrycrush/samples/webflux/WebFluxCustomStep.java
+++ b/samples/webflux/scenario/src/test/java/org/berrycrush/samples/webflux/WebFluxCustomStep.java
@@ -1,0 +1,19 @@
+package org.berrycrush.samples.webflux;
+
+import org.berrycrush.samples.webflux.service.DependencyService;
+import org.berrycrush.step.Step;
+import org.springframework.stereotype.Component;
+
+@Component
+public class WebFluxCustomStep {
+    private final DependencyService dependencyService;
+    public WebFluxCustomStep(DependencyService dependencyService) {
+        this.dependencyService = dependencyService;
+    }
+
+    @Step("check name {string} and price {int}")
+    public void checkProduct(String name, int price) {
+        System.out.println("Checking product with name: " + name + " and price: " + price);
+        dependencyService.performAction();
+    }
+}

--- a/samples/webflux/scenario/src/test/java/org/berrycrush/samples/webflux/WebFluxScenarioTest.java
+++ b/samples/webflux/scenario/src/test/java/org/berrycrush/samples/webflux/WebFluxScenarioTest.java
@@ -4,9 +4,11 @@ import org.berrycrush.junit.BerryCrushConfiguration;
 import org.berrycrush.junit.BerryCrushScenarios;
 import org.berrycrush.junit.BerryCrushSpec;
 import org.berrycrush.spring.BerryCrushContextConfiguration;
+import org.berrycrush.spring.SpringStepDiscovery;
 import org.junit.platform.suite.api.IncludeEngines;
 import org.junit.platform.suite.api.Suite;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 
 
 /**
@@ -17,11 +19,13 @@ import org.springframework.boot.test.context.SpringBootTest;
 @Suite
 @IncludeEngines("berrycrush")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Import(SpringStepDiscovery.class)
 @BerryCrushContextConfiguration
 @BerryCrushScenarios(locations = {"scenarios/*.scenario"})
 @BerryCrushConfiguration(
-    bindings = WebFluxBindings.class, 
-    plugins = {"report:text", "report:console:high-contrast"}
+        bindings = WebFluxBindings.class,
+        plugins = {"report:text", "report:console:high-contrast"},
+        stepPackages = {"org.berrycrush.samples.webflux"}
 )
 @BerryCrushSpec(paths = {"webflux-products.yaml"})
 public class WebFluxScenarioTest {

--- a/samples/webflux/scenario/src/test/java/org/berrycrush/samples/webflux/service/DependencyService.java
+++ b/samples/webflux/scenario/src/test/java/org/berrycrush/samples/webflux/service/DependencyService.java
@@ -1,0 +1,10 @@
+package org.berrycrush.samples.webflux.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class DependencyService {
+    public void performAction() {
+        System.out.println("DependencyComponent action performed.");
+    }
+}

--- a/samples/webflux/scenario/src/test/resources/scenarios/01-crud-operations.scenario
+++ b/samples/webflux/scenario/src/test/resources/scenarios/01-crud-operations.scenario
@@ -125,4 +125,4 @@ scenario: Search products by name
       search: "Laptop"
   then: I receive matching products
     assert status 200
-    # May be empty if no matching products exist
+  and check name "product" and price 10


### PR DESCRIPTION
`junit` module now provides `RegistryProvider` to provide custom step and assertion registry.